### PR TITLE
Fix PIP Install Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package has been tested on a RasperryPI ZeroW with Raspbian GNU/Linux 9 (st
 
 ## 1. Install with:
 
-`pip install pydecora_ble`
+`pip install decora-ble`
 
 ## 2. Short example
 


### PR DESCRIPTION
According to this page: https://pypi.org/project/decora-ble/ the install command is pip install decora-ble. pip install pydecora_ble doesnt work.